### PR TITLE
Add configuration variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ SSL is enabled by default and requires certificates to be configured.
 See the [SSL Configuration](#ssl-configuration) section for more information.
 
 ## Configuration
-| Key | Description |
-|-----|-------------|
-| `tiller_version`      | The version of tiller to install. |
-| `tiller_namespace`    | The namespace to install tiller. |
-| `tiller_cluster_role` | The cluster role to grant to the tiller service account. |
+| Key | Description | Default |
+|-----|-------------|---------|
+| `tiller_registry`         | The registry where is the tiller image. | `grc.io` |
+| `tiller_repository`       | The repository where is the tiller image. | `kubernetes-helm/tiller` |
+| `tiller_tag`              | The tiller image tag. | `v2.12.0` |
+| `tiller_namespace`        | The namespace to install tiller. | `kube-system` |
+| `tiller_cluster_role`     | The cluster role to grant to the tiller service account. | `cluster-admin` |
+| `tiller_history_max`      | Limits the maximum number of revisions saved per release. | `0` (no limit)
+| `tiller_kubeconfig_path`  | The path of your kubeconfig file. | `/etc/kubernetes/kubeconfig-local`
 
 ## SSL Configuration
 Keys and certificates are loaded from the locations shown below.
@@ -27,7 +31,10 @@ The `jumperfly.ssl_cert` role can be used to generate them if required. For exam
       - 127.0.0.1
 ```
 
-| Key | Description |
-|-----|-------------|
-| `tiller_secret_name`      | The name of the kubernetes secret holding the tiller certificates. |
-| `tiller-secret_namespace` | The name of the kubernetes secret holding the tiller certificates. |
+| Key | Description | Default |
+|-----|-------------|---------|
+| `tiller_secret_name`      | The name of the kubernetes secret holding the tiller certificates. | `tiller-secret` |
+| `tiller-secret_namespace` | The name of the kubernetes secret holding the tiller certificates. | `kube-system` |
+| `tiller_tls_verify`       | If set, verify remote certificates. | `1` |
+| `tiller_tls_enable`       | If set, install Tiller with TLS.    | `1` |
+| `tiller_tls_certs`        | Certificates location.              | `/etc/cert` |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The `jumperfly.ssl_cert` role can be used to generate them if required. For exam
 |-----|-------------|---------|
 | `tiller_secret_name`      | The name of the kubernetes secret holding the tiller certificates. | `tiller-secret` |
 | `tiller-secret_namespace` | The name of the kubernetes secret holding the tiller certificates. | `kube-system` |
-| `tiller_tls_verify`       | If set, verify remote certificates. | `1` |
-| `tiller_tls_enable`       | If set, install Tiller with TLS.    | `1` |
+| `tiller_tls_verify`       | If set`*`, verify remote certificates. | `1` |
+| `tiller_tls_enable`       | If set`*`, install Tiller with TLS.    | `1` |
 | `tiller_tls_certs`        | Certificates location.              | `/etc/cert` |
+
+`*` If set: In the current Tiller version, the only way to disable `tiller_tls_verify` and `tiller_tls_enable` is to have them empty. [Here](https://github.com/helm/helm/blob/17c2272490c21bf70c4ae6b8dd7d312cb020307f/cmd/tiller/tiller.go#L279-L280) is the corresponding code.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 tiller_namespace: kube-system
 tiller_cluster_role: cluster-admin
 tiller_history_max: 0
-tiller_tls_certs: /etc/cert
 tiller_kubeconfig_path: /etc/kubernetes/kubeconfig-local
 
 # Tiller repository
@@ -15,3 +14,4 @@ tiller_secret_name: tiller-secret
 tiller_secret_namespace: kube-system
 tiller_tls_verify: 1
 tiller_tls_enable: 1
+tiller_tls_certs: /etc/cert

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,17 @@
 # Tiller configuration
-tiller_version: 2.12.0
 tiller_namespace: kube-system
-tiller_cluster_role: kube-admin
+tiller_cluster_role: cluster-admin
+tiller_history_max: 0
+tiller_tls_certs: /etc/cert
+tiller_kubeconfig_path: /etc/kubernetes/kubeconfig-local
+
+# Tiller repository
+tiller_registry: gcr.io
+tiller_repository: kubernetes-helm/tiller
+tiller_tag: v2.12.0
 
 # SSL Configuration
 tiller_secret_name: tiller-secret
 tiller_secret_namespace: kube-system
+tiller_tls_verify: 1
+tiller_tls_enable: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,9 +58,9 @@
               - name: TILLER_HISTORY_MAX
                 value: "{{ tiller_history_max }}"
               - name: TILLER_TLS_VERIFY
-                value: "{{ tiller_tls_verify }}"
+                value: "{{ tiller_tls_verify | string }}"
               - name: TILLER_TLS_ENABLE
-                value: "{{ tiller_tls_enable }}"
+                value: "{{ tiller_tls_enable | string }}"
               - name: TILLER_TLS_CERTS
                 value: "{{ tiller_tls_certs }}"
               readinessProbe:
@@ -98,7 +98,7 @@
             - name: tiller-certs
               secret:
                 secretName: "{{ tiller_secret_name }}"
-                optional: "{{ 'false' if is defined tiller_tls_enable else 'true' }}"
+                optional: "{{ not tiller_tls_enable }}"
     - apiVersion: v1
       kind: Service
       metadata:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Deploy tiller
   k8s:
-    kubeconfig: /etc/kubernetes/kubeconfig-local
+    kubeconfig: "{{ tiller_kubeconfig_path }}"
     definition: "{{ item }}"
   loop_control:
     label: "{{ item.kind }}/{{ item.metadata.name }}"
@@ -50,19 +50,19 @@
             serviceAccountName: tiller
             containers:
             - name: tiller
-              image: gcr.io/kubernetes-helm/tiller:v{{ tiller_version }}
+              image: '{{tiller_registry}}/{{tiller_repository}}:{{tiller_tag}}'
               imagePullPolicy: IfNotPresent
               env:
               - name: TILLER_NAMESPACE
                 value: "{{ tiller_namespace }}"
               - name: TILLER_HISTORY_MAX
-                value: "0"
+                value: "{{ tiller_history_max }}"
               - name: TILLER_TLS_VERIFY
-                value: "1"
+                value: "{{ tiller_tls_verify }}"
               - name: TILLER_TLS_ENABLE
-                value: "1"
+                value: "{{ tiller_tls_enable }}"
               - name: TILLER_TLS_CERTS
-                value: /etc/certs
+                value: "{{ tiller_tls_certs }}"
               readinessProbe:
                 failureThreshold: 3
                 httpGet:
@@ -91,13 +91,14 @@
                 name: http
                 protocol: TCP
               volumeMounts:
-              - mountPath: /etc/certs
+              - mountPath: "{{ tiller_tls_certs }}"
                 name: tiller-certs
                 readOnly: true
             volumes:
             - name: tiller-certs
               secret:
                 secretName: "{{ tiller_secret_name }}"
+                optional: true
     - apiVersion: v1
       kind: Service
       metadata:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
               - name: TILLER_NAMESPACE
                 value: "{{ tiller_namespace }}"
               - name: TILLER_HISTORY_MAX
-                value: "{{ tiller_history_max }}"
+                value: "{{ tiller_history_max | string }}"
               - name: TILLER_TLS_VERIFY
                 value: "{{ tiller_tls_verify | string }}"
               - name: TILLER_TLS_ENABLE

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,7 @@
             - name: tiller-certs
               secret:
                 secretName: "{{ tiller_secret_name }}"
-                optional: true
+                optional: "{{ 'false' if is defined tiller_tls_enable else 'true' }}"
     - apiVersion: v1
       kind: Service
       metadata:


### PR DESCRIPTION
Hi,

I'm currently working on a Raspberry Pi 4 cluster using k3s and needed to be able to install Tiller without SSL and to choose and arm64 tiller image. 
So I had to add multiple variables to disable SSL and beeing able to change the tiller image.
I added every new variables to the README.

I only tested it on my Raspberry Pi 4 cluster without SSL. Everything worked as expected. SSL must still works as correctly but those modifications might need more tests. It would be great if some of you could test it.

I hope everything is clear.
If needed, I can explain my code in comment.